### PR TITLE
Add ToSC and TCHES journals to manual

### DIFF
--- a/views/default/manual.html
+++ b/views/default/manual.html
@@ -173,6 +173,14 @@ letter is added at the end of each label starting with <i>'a'</i>:</p>
           <td>Journal of Cryptology</td>
           <td><strong>JC</strong></td>
         </tr>
+        <tr>
+          <td>IACR Transactions on Cryptographic Hardware and Embedded Systems</td>
+          <td><strong>TCHES</strong></td>
+        </tr>
+        <tr>
+          <td>IACR Transactions on Symmetric Cryptology</td>
+          <td><strong>ToSC</strong></td>
+        </tr>
       </table>
 
       <h3>Misc labels</h3>


### PR DESCRIPTION
This PR adds the two IACR journals, _ToSC_ and _TCHES_ to the [manual](https://cryptobib.di.ens.fr/manual)'s section on labeling conventions. I thought, this would be nice for consistency.